### PR TITLE
[GitUp] libgit v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 tags
 CMakeSettings.json
 .vs
+
+#swisspol (GitUp)
+xcode

--- a/cmake/FindLIBSSH2.cmake
+++ b/cmake/FindLIBSSH2.cmake
@@ -1,0 +1,43 @@
+if (LIBSSH2_LIBRARIES AND LIBSSH2_INCLUDE_DIRS)
+  set(LIBSSH2_FOUND TRUE)
+else (LIBSSH2_LIBRARIES AND LIBSSH2_INCLUDE_DIRS)
+  find_path(LIBSSH2_INCLUDE_DIR
+    NAMES
+      libssh2.h
+    PATHS
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+      ${CMAKE_INCLUDE_PATH}
+      ${CMAKE_INSTALL_PREFIX}/include
+  )
+  
+  find_library(LIBSSH2_LIBRARY
+    NAMES
+      ssh2
+      libssh2
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+      ${CMAKE_LIBRARY_PATH}
+      ${CMAKE_INSTALL_PREFIX}/lib
+  )
+
+  if (LIBSSH2_INCLUDE_DIR AND LIBSSH2_LIBRARY)
+    set(LIBSSH2_FOUND TRUE)
+  endif (LIBSSH2_INCLUDE_DIR AND LIBSSH2_LIBRARY)
+
+  if (LIBSSH2_FOUND)
+    set(LIBSSH2_INCLUDE_DIRS
+      ${LIBSSH2_INCLUDE_DIR}
+    )
+
+    set(LIBSSH2_LIBRARIES
+      ${LIBSSH2_LIBRARIES}
+      ${LIBSSH2_LIBRARY}
+    )
+  endif (LIBSSH2_FOUND)
+endif (LIBSSH2_LIBRARIES AND LIBSSH2_INCLUDE_DIRS)

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -264,6 +264,10 @@ typedef struct {
 	uint32_t           flags;
 	uint16_t           mode;
 	uint16_t           id_abbrev;
+
+	/// PATCH
+	git_time_t         ctime;
+	git_time_t         mtime;
 } git_diff_file;
 
 /**

--- a/include/git2/gitup_branch.h
+++ b/include/git2/gitup_branch.h
@@ -1,0 +1,20 @@
+#include "common.h"
+#include "oid.h"
+#include "types.h"
+
+/**
+ * @file git2/branch.h
+ * @brief Git branch parsing routines
+ * @defgroup git_branch Git branch management
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+// PATCH
+/// This method can be ignored. Use `gitup_branch_upstream_name` instead.
+GIT_EXTERN(int) gitup_branch_upstream_name_from_merge_remote_names(git_buf *out, git_repository *repo, const char *remote_name, const char *merge_name);
+/// Use this method.
+GIT_EXTERN(int) gitup_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname);
+
+/** @} */
+GIT_END_DECL

--- a/include/git2/gitup_branch.h
+++ b/include/git2/gitup_branch.h
@@ -16,5 +16,10 @@ GIT_EXTERN(int) gitup_branch_upstream_name_from_merge_remote_names(git_buf *out,
 /// Use this method.
 GIT_EXTERN(int) gitup_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname);
 
+// PATCH
+/// These methods could be (?) replaced by `gitup_branch_upstream_name` also.
+GIT_EXTERN(int) gitup_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname);
+GIT_EXTERN(int) gitup_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname);
+
 /** @} */
 GIT_END_DECL

--- a/include/git2/gitup_branch.h
+++ b/include/git2/gitup_branch.h
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "oid.h"
 #include "types.h"
+#include "branch.h"
 
 /**
  * @file git2/branch.h

--- a/include/git2/gitup_clone.h
+++ b/include/git2/gitup_clone.h
@@ -1,0 +1,66 @@
+#include "clone.h"
+#include "common.h"
+#include "types.h"
+#include "indexer.h"
+#include "checkout.h"
+#include "remote.h"
+#include "transport.h"
+
+
+/**
+ * @file git2/clone.h
+ * @brief Git cloning routines
+ * @defgroup git_clone Git cloning routines
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Clone a remote repository.
+ *
+ * By default this creates its repository and initial remote to match
+ * git's defaults. You can use the options in the callback to
+ * customize how these are created.
+ *
+ * @param out pointer that will receive the resulting repository object
+ * @param url the remote repository to clone
+ * @param local_path local directory to clone to
+ * @param options configuration options for the clone.  If NULL, the
+ *        function works as though GIT_OPTIONS_INIT were passed.
+ * @return 0 on success, any non-zero return value from a callback
+ *         function, or a negative value to indicate an error (use
+ *         `git_error_last` for a detailed error message)
+ */
+
+/// Use `git_clone instead.
+GIT_EXTERN(int) gitup_clone_into(
+	git_repository **out,
+	const char *url,
+	const char *local_path,
+	const git_clone_options *options
+	);
+
+/// Deprecated
+/**
+ * Clone a remote repository into an existing empty repository using
+ * a pre-existing remote.
+ *
+ * @param repo the repository to clone into
+ * @param remote the remote to use for cloning
+ * @param fetch_opts the fetch options to use
+ * @param checkout_opts the checkout options to use
+ * @param branch name of the branch to checkout (NULL means use the
+ *        remote's default branch)
+ * @return 0 on success, any non-zero return value from a callback
+ *         function, or a negative value to indicate an error
+ */
+GIT_EXTERN(int) gitup_clone_into_old(
+	git_repository *repo,
+	git_remote *remote,
+	const git_fetch_options *fetch_opts,
+	const git_checkout_options *checkout_opts,
+	const char *branch);
+
+/** @} */
+GIT_END_DECL

--- a/include/git2/gitup_clone.h
+++ b/include/git2/gitup_clone.h
@@ -6,7 +6,6 @@
 #include "remote.h"
 #include "transport.h"
 
-
 /**
  * @file git2/clone.h
  * @brief Git cloning routines

--- a/include/git2/gitup_config.h
+++ b/include/git2/gitup_config.h
@@ -12,6 +12,6 @@ GIT_BEGIN_DECL
  * @param out Pointer to a user-allocated git_buf in which to store the path
  * @return 0 if a local configuration file has been found. Its path will be stored in `out`.
  */
-GIT_EXTERN(int) git_config_find_local(git_repository *repo, git_buf *out);
+GIT_EXTERN(int) gitup_config_find_local(git_repository *repo, git_buf *out);
 
 GIT_END_DECL

--- a/include/git2/gitup_config.h
+++ b/include/git2/gitup_config.h
@@ -12,6 +12,8 @@ GIT_BEGIN_DECL
  * @param out Pointer to a user-allocated git_buf in which to store the path
  * @return 0 if a local configuration file has been found. Its path will be stored in `out`.
  */
+/// This function uses repository method item path.
+/// Maybe it is better to use `repository` method `gitup_repository_find_local_config`
 GIT_EXTERN(int) gitup_config_find_local(git_repository *repo, git_buf *out);
 
 GIT_END_DECL

--- a/include/git2/gitup_config.h
+++ b/include/git2/gitup_config.h
@@ -1,0 +1,17 @@
+#include "config.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * Locate the path to the local configuration file
+ *
+ * The returned path may be used on any `git_config` call to load the local
+ * configuration file.
+ *
+ * @param repo The repository whose local configuration file to find
+ * @param out Pointer to a user-allocated git_buf in which to store the path
+ * @return 0 if a local configuration file has been found. Its path will be stored in `out`.
+ */
+GIT_EXTERN(int) git_config_find_local(git_repository *repo, git_buf *out);
+
+GIT_END_DECL

--- a/include/git2/gitup_refs.h
+++ b/include/git2/gitup_refs.h
@@ -4,6 +4,9 @@ GIT_BEGIN_DECL
 
 /**
  * Create a virtual direct reference.
+ * 
+ * This is wrapper for
+ * git_reference_create(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force, const char *log_message);
  *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference virtually lives
@@ -15,6 +18,11 @@ GIT_EXTERN(int) gitup_reference_create_virtual(git_reference **out, git_reposito
 
 /**
  * Create a virtual symbolic reference.
+ * 
+ * Discussion
+ * 
+ * This is a wrapper for
+ * git_reference_symbolic_create(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const char *log_message);
  *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference virtually lives

--- a/include/git2/gitup_refs.h
+++ b/include/git2/gitup_refs.h
@@ -1,0 +1,27 @@
+#include "refs.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * Create a virtual direct reference.
+ *
+ * @param out Pointer to the newly created reference
+ * @param repo Repository where that reference virtually lives
+ * @param name The name of the reference
+ * @param id The object id pointed to by the reference
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) gitup_reference_create_virtual(git_reference **out, git_repository *repo, const char *name, const git_oid *id);
+
+/**
+ * Create a virtual symbolic reference.
+ *
+ * @param out Pointer to the newly created reference
+ * @param repo Repository where that reference virtually lives
+ * @param name The name of the reference
+ * @param target The target of the reference
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) gitup_reference_symbolic_create_virtual(git_reference **out, git_repository *repo, const char *name, const char *target);
+
+GIT_END_DECL

--- a/include/git2/gitup_repository.h
+++ b/include/git2/gitup_repository.h
@@ -5,7 +5,7 @@
 #include "buffer.h"
 
 /**
- * @file git2/repository.h
+ * @file git2/gitup_repository.h
  * @brief Git repository management routines
  * @defgroup git_repository Git repository management routines
  * @ingroup Git
@@ -18,6 +18,18 @@ GIT_BEGIN_DECL
  */
 GIT_EXTERN(int) gitup_repository_update_gitlink(
     git_repository *repo, int use_relative_path);
+
+/**
+ * Locate the path to the local configuration file
+ *
+ * The returned path may be used on any `git_config` call to load the local
+ * configuration file.
+ *
+ * @param repo The repository whose local configuration file to find
+ * @param out Pointer to a user-allocated git_buf in which to store the path
+ * @return 0 if a local configuration file has been found. Its path will be stored in `out`.
+ */
+GIT_EXTERN(int) gitup_repository_local_config_path(git_buf *out, git_repository *repo);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/gitup_repository.h
+++ b/include/git2/gitup_repository.h
@@ -1,0 +1,23 @@
+#include "repository.h"
+#include "common.h"
+#include "types.h"
+#include "oid.h"
+#include "buffer.h"
+
+/**
+ * @file git2/repository.h
+ * @brief Git repository management routines
+ * @defgroup git_repository Git repository management routines
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Update or rewrite the gitlink in the workdir
+ */
+GIT_EXTERN(int) git_repository_update_gitlink(
+    git_repository *repo, int use_relative_path);
+
+/** @} */
+GIT_END_DECL

--- a/include/git2/gitup_repository.h
+++ b/include/git2/gitup_repository.h
@@ -16,7 +16,7 @@ GIT_BEGIN_DECL
 /**
  * Update or rewrite the gitlink in the workdir
  */
-GIT_EXTERN(int) git_repository_update_gitlink(
+GIT_EXTERN(int) gitup_repository_update_gitlink(
     git_repository *repo, int use_relative_path);
 
 /** @} */

--- a/include/git2/gitup_submodule.h
+++ b/include/git2/gitup_submodule.h
@@ -1,0 +1,12 @@
+#include "submodule.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * Retains a submodule
+ *
+ * @param submodule Submodule object
+ */
+GIT_EXTERN(void) gitup_submodule_retain(git_submodule *submodule);
+
+GIT_END_DECL

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -457,10 +457,11 @@ typedef struct {
  *
  * @param updates an array containing the updates which will be sent
  * as commands to the destination.
+ * @param the remote being pushed /// PATCH
  * @param len number of elements in `updates`
  * @param payload Payload provided by the caller
  */
-typedef int GIT_CALLBACK(git_push_negotiation)(const git_push_update **updates, size_t len, void *payload);
+typedef int GIT_CALLBACK(git_push_negotiation)(git_remote *remote, const git_push_update **updates, size_t len, void *payload);
 
 /**
  * Callback used to inform of the update status from the remote.

--- a/include/gitup_extensions.h
+++ b/include/gitup_extensions.h
@@ -3,3 +3,4 @@
 #include "git2/gitup_submodule.h"
 #include "git2/gitup_refs.h"
 #include "git2/gitup_config.h"
+#include "git2/gitup_branch.h"

--- a/include/gitup_extensions.h
+++ b/include/gitup_extensions.h
@@ -1,3 +1,4 @@
 
 #include "git2.h"
 #include "git2/gitup_submodule.h"
+#include "git2/gitup_refs.h"

--- a/include/gitup_extensions.h
+++ b/include/gitup_extensions.h
@@ -5,3 +5,4 @@
 #include "git2/gitup_config.h"
 #include "git2/gitup_branch.h"
 #include "git2/gitup_clone.h"
+#include "git2/gitup_repository.h"

--- a/include/gitup_extensions.h
+++ b/include/gitup_extensions.h
@@ -4,3 +4,4 @@
 #include "git2/gitup_refs.h"
 #include "git2/gitup_config.h"
 #include "git2/gitup_branch.h"
+#include "git2/gitup_clone.h"

--- a/include/gitup_extensions.h
+++ b/include/gitup_extensions.h
@@ -2,3 +2,4 @@
 #include "git2.h"
 #include "git2/gitup_submodule.h"
 #include "git2/gitup_refs.h"
+#include "git2/gitup_config.h"

--- a/include/gitup_extensions.h
+++ b/include/gitup_extensions.h
@@ -1,0 +1,3 @@
+
+#include "git2.h"
+#include "git2/gitup_submodule.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -277,6 +277,7 @@ target_compile_definitions(git2internal PRIVATE _FILE_OFFSET_BITS=64)
 
 # Collect sourcefiles
 file(GLOB SRC_H
+    "${libgit2_SOURCE_DIR}/include/gitup_extensions.h"
 	"${libgit2_SOURCE_DIR}/include/git2.h"
 	"${libgit2_SOURCE_DIR}/include/git2/*.h"
 	"${libgit2_SOURCE_DIR}/include/git2/sys/*.h")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -210,7 +210,7 @@ ENDIF()
 
 # Optional external dependency: libssh2
 IF (USE_SSH)
-	FIND_PKGLIBRARIES(LIBSSH2 libssh2)
+	FIND_PACKAGE(LIBSSH2)
 ENDIF()
 IF (LIBSSH2_FOUND)
 	SET(GIT_SSH 1)

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -169,12 +169,22 @@ static int diff_delta__from_one(
 		delta->old_file.flags |= GIT_DIFF_FLAG_EXISTS;
 		git_oid_cpy(&delta->old_file.id, &entry->id);
 		delta->old_file.id_abbrev = GIT_OID_HEXSZ;
+
+		/// PATCH
+		delta->old_file.mtime = entry->mtime.seconds;
+		delta->old_file.ctime = entry->ctime.seconds;
+
 	} else /* ADDED, IGNORED, UNTRACKED */ {
 		delta->new_file.mode = entry->mode;
 		delta->new_file.size = entry->file_size;
 		delta->new_file.flags |= GIT_DIFF_FLAG_EXISTS;
 		git_oid_cpy(&delta->new_file.id, &entry->id);
 		delta->new_file.id_abbrev = GIT_OID_HEXSZ;
+
+		/// PATCH
+		delta->new_file.mtime = entry->mtime.seconds;
+		delta->new_file.ctime = entry->ctime.seconds;
+
 	}
 
 	delta->old_file.flags |= GIT_DIFF_FLAG_VALID_ID;
@@ -230,6 +240,11 @@ static int diff_delta__from_two(
 		delta->old_file.id_abbrev = GIT_OID_HEXSZ;
 		delta->old_file.flags |= GIT_DIFF_FLAG_VALID_ID |
 			GIT_DIFF_FLAG_EXISTS;
+
+		/// PATCH
+		delta->old_file.mtime = old_entry->mtime.seconds;
+		delta->old_file.ctime = old_entry->ctime.seconds;
+
 	}
 
 	if (!git_index_entry_is_conflict(new_entry)) {
@@ -239,6 +254,11 @@ static int diff_delta__from_two(
 		delta->new_file.mode = new_mode;
 		delta->old_file.flags |= GIT_DIFF_FLAG_EXISTS;
 		delta->new_file.flags |= GIT_DIFF_FLAG_EXISTS;
+
+		/// PATCH
+		delta->new_file.mtime = new_entry->mtime.seconds;
+		delta->new_file.ctime = new_entry->ctime.seconds;
+
 
 		if (!git_oid_is_zero(&new_entry->id))
 			delta->new_file.flags |= GIT_DIFF_FLAG_VALID_ID;

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -108,6 +108,11 @@ git_diff_delta *git_diff__merge_like_cgit(
 	dup->old_file.size  = a->old_file.size;
 	dup->old_file.flags = a->old_file.flags;
 
+	/// PATCH
+	dup->old_file.mtime = a->old_file.mtime;
+	dup->old_file.ctime = a->old_file.ctime;
+
+
 	return dup;
 }
 

--- a/src/gitup_branch.c
+++ b/src/gitup_branch.c
@@ -1,0 +1,53 @@
+#include "branch.h"
+
+#include "commit.h"
+#include "tag.h"
+#include "config.h"
+#include "refspec.h"
+#include "refs.h"
+#include "remote.h"
+#include "annotated_commit.h"
+#include "worktree.h"
+
+#include "git2/branch.h"
+
+int gitup_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname) {
+	git_branch_upstream_name(out, repo, refname);
+}
+
+/// Ignore this method.
+int gitup_branch_upstream_name_from_merge_remote_names(git_buf *out, git_repository *repo, const char *remote_name, const char *merge_name) {
+	return -1;
+	git_buf buf = GIT_BUF_INIT;
+	int error = -1;
+	git_remote *remote = NULL;
+	const git_refspec *refspec;
+
+	assert(out && remote_name && merge_name);
+
+	git_buf_sanitize(out);
+
+	if (strcmp(".", remote_name) != 0) {
+		if ((error = git_remote_lookup(&remote, repo, remote_name)) < 0)
+			goto cleanup;
+
+		refspec = git_remote__matching_refspec(remote, merge_name);
+		if (!refspec) {
+			error = GIT_ENOTFOUND;
+			goto cleanup;
+		}
+
+		if (git_refspec_transform(&buf, refspec, merge_name) < 0)
+			goto cleanup;
+	} else
+		if (git_buf_set(&buf, merge_name, strlen(merge_name)) < 0)
+			goto cleanup;
+
+	error = git_buf_set(out, git_buf_cstr(&buf), git_buf_len(&buf));
+
+cleanup:
+	git_remote_free(remote);
+	git_buf_free(&buf);
+	return error;
+}
+

--- a/src/gitup_branch.c
+++ b/src/gitup_branch.c
@@ -1,15 +1,12 @@
 #include "branch.h"
 
 #include "commit.h"
-#include "tag.h"
 #include "config.h"
-#include "refspec.h"
 #include "refs.h"
 #include "remote.h"
-#include "annotated_commit.h"
-#include "worktree.h"
 
 #include "git2/branch.h"
+#include "git2/gitup_branch.h"
 
 int gitup_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname) {
 	return git_branch_upstream_name(out, repo, refname);

--- a/src/gitup_branch.c
+++ b/src/gitup_branch.c
@@ -51,3 +51,32 @@ cleanup:
 	return error;
 }
 
+/// Actually, you have to use `git_branch_upstream_name`.
+/// This method is dup of method `retrieve_upstream_configuration` in `branch.c`
+static int gitup_retrieve_upstream_configuration(
+	git_buf *out,
+	const git_config *config,
+	const char *canonical_branch_name,
+	const char *format)
+{
+	git_buf buf = GIT_BUF_INIT;
+	int error;
+
+	if (git_buf_printf(&buf, format,
+		canonical_branch_name + strlen(GIT_REFS_HEADS_DIR)) < 0)
+			return -1;
+
+	error = git_config_get_string_buf(out, config, git_buf_cstr(&buf));
+	git_buf_dispose(&buf);
+	return error;
+}
+
+int gitup_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname)
+{
+	return gitup_retrieve_upstream_configuration(buf, repo, refname, "branch.%s.remote");
+}
+
+int gitup_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname)
+{
+	return gitup_retrieve_upstream_configuration(buf, repo, refname, "branch.%s.merge");
+}

--- a/src/gitup_branch.c
+++ b/src/gitup_branch.c
@@ -12,17 +12,18 @@
 #include "git2/branch.h"
 
 int gitup_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname) {
-	git_branch_upstream_name(out, repo, refname);
+	return git_branch_upstream_name(out, repo, refname);
 }
 
 /// Ignore this method.
+/// This method should be removed.
 int gitup_branch_upstream_name_from_merge_remote_names(git_buf *out, git_repository *repo, const char *remote_name, const char *merge_name) {
 	return -1;
-	git_buf buf = GIT_BUF_INIT;
 	int error = -1;
 	git_remote *remote = NULL;
 	const git_refspec *refspec;
-
+    git_buf buf = GIT_BUF_INIT;
+    
 	assert(out && remote_name && merge_name);
 
 	git_buf_sanitize(out);
@@ -71,12 +72,21 @@ static int gitup_retrieve_upstream_configuration(
 	return error;
 }
 
+static int gitup_branch_upstream_format(git_buf *buf, git_repository *repo, const char *refname, const char *format) {
+    int error;
+    git_config *config;
+    if ((error = git_repository_config_snapshot(&config, repo)) < 0)
+        return error;
+    return gitup_retrieve_upstream_configuration(buf, config, refname, format);
+}
+
+/// May be in PR.
 int gitup_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname)
 {
-	return gitup_retrieve_upstream_configuration(buf, repo, refname, "branch.%s.remote");
+	return gitup_branch_upstream_format(buf, repo, refname, "branch.%s.remote");
 }
 
 int gitup_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname)
 {
-	return gitup_retrieve_upstream_configuration(buf, repo, refname, "branch.%s.merge");
+	return gitup_branch_upstream_format(buf, repo, refname, "branch.%s.merge");
 }

--- a/src/gitup_branch.c
+++ b/src/gitup_branch.c
@@ -15,10 +15,9 @@ int gitup_branch_upstream_name(git_buf *out, git_repository *repo, const char *r
 /// Ignore this method.
 /// This method should be removed.
 int gitup_branch_upstream_name_from_merge_remote_names(git_buf *out, git_repository *repo, const char *remote_name, const char *merge_name) {
-	return -1;
 	int error = -1;
 	git_remote *remote = NULL;
-	const git_refspec *refspec;
+	const git_refspec *refspec = NULL;
     git_buf buf = GIT_BUF_INIT;
     
 	assert(out && remote_name && merge_name);

--- a/src/gitup_clone.c
+++ b/src/gitup_clone.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "clone.h"
+
+#include "git2/clone.h"
+#include "git2/remote.h"
+#include "git2/repository.h"
+#include "git2/revparse.h"
+#include "git2/branch.h"
+#include "git2/config.h"
+#include "git2/checkout.h"
+#include "git2/commit.h"
+#include "git2/tree.h"
+
+#include "remote.h"
+#include "futils.h"
+#include "refs.h"
+#include "path.h"
+#include "repository.h"
+#include "odb.h"
+
+GIT_EXTERN(int) gitup_clone_into(
+	git_repository **out,
+	const char *url,
+	const char *local_path,
+	const git_clone_options *options
+	) {
+	return git_clone(out, url, local_path, options);
+}
+
+GIT_EXTERN(int) gitup_clone_into_old(
+	git_repository *repo,
+	git_remote *remote,
+	const git_fetch_options *fetch_opts,
+	const git_checkout_options *checkout_opts,
+	const char *branch) {
+	/// We have to create git_clone_options
+	assert(repo && remote && fetch_opts && checkout_opts);
+	git_clone_options *options = GIT_CLONE_OPTIONS_INIT;
+
+	options.checkout_opts = checkout_opts;
+	options.fetch_opts = fetch_options;
+	options.checkout_branch = branch;
+	const char *url = git_remote_url(remote);
+	const char *local_path = git_repository_path(repo);
+	return gitup_clone_into(&repo, url, local_path, options);
+}

--- a/src/gitup_clone.c
+++ b/src/gitup_clone.c
@@ -10,17 +10,12 @@
 #include "git2/clone.h"
 #include "git2/remote.h"
 #include "git2/repository.h"
-#include "git2/revparse.h"
-#include "git2/branch.h"
 #include "git2/config.h"
 #include "git2/checkout.h"
-#include "git2/commit.h"
-#include "git2/tree.h"
 
 #include "remote.h"
 #include "futils.h"
 #include "refs.h"
-#include "path.h"
 #include "repository.h"
 #include "odb.h"
 

--- a/src/gitup_clone.c
+++ b/src/gitup_clone.c
@@ -39,14 +39,16 @@ GIT_EXTERN(int) gitup_clone_into_old(
 	const git_fetch_options *fetch_opts,
 	const git_checkout_options *checkout_opts,
 	const char *branch) {
+	git_clone_options options = GIT_CLONE_OPTIONS_INIT;
+	const char *url;
+	const char *local_path;
 	/// We have to create git_clone_options
 	assert(repo && remote && fetch_opts && checkout_opts);
-	git_clone_options *options = GIT_CLONE_OPTIONS_INIT;
 
-	options.checkout_opts = checkout_opts;
-	options.fetch_opts = fetch_options;
+	options.checkout_opts = *checkout_opts;
+	options.fetch_opts = *fetch_opts;
 	options.checkout_branch = branch;
-	const char *url = git_remote_url(remote);
-	const char *local_path = git_repository_path(repo);
-	return gitup_clone_into(&repo, url, local_path, options);
+	url = git_remote_url(remote);
+	local_path = git_repository_path(repo);
+	return gitup_clone_into(&repo, url, local_path, &options);
 }

--- a/src/gitup_config.c
+++ b/src/gitup_config.c
@@ -15,16 +15,16 @@
 
 #include <ctype.h>
 
-int git_config_find_local(git_repository *repo, git_buf *path)
+int gitup_config_find_local(git_repository *repo, git_buf *path)
 {
 	assert(repo);
 
 	git_buf_sanitize(path);
 	if (git_buf_joinpath(path, repo->gitdir, GIT_CONFIG_FILENAME_INREPO) < 0)
-    return -1;
+		return -1;
 
 	if (!git_path_exists(path->ptr)) {
-		giterr_set(GITERR_OS, "The config file '%s' doesn't exist", path->ptr);
+		git_error_set(GIT_ERROR_OS, "The config file '%s' doesn't exist", path->ptr);
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/gitup_config.c
+++ b/src/gitup_config.c
@@ -1,20 +1,7 @@
-#include "config.h"
-#include "git2/config.h"
 #include "git2/gitup_config.h"
-#include "vector.h"
+#include "git2/repository.h"
 
 int gitup_config_find_local(git_repository *repo, git_buf *path)
 {
-	assert(repo);
-
-	git_buf_sanitize(path);
-	if (git_buf_joinpath(path, repo->gitdir, GIT_CONFIG_FILENAME_INREPO) < 0)
-		return -1;
-
-	if (!git_path_exists(path->ptr)) {
-		git_error_set(GIT_ERROR_OS, "The config file '%s' doesn't exist", path->ptr);
-		return GIT_ENOTFOUND;
-	}
-
-	return 0;
+	return git_repository_item_path(path, repo, GIT_REPOSITORY_ITEM_CONFIG);
 }

--- a/src/gitup_config.c
+++ b/src/gitup_config.c
@@ -1,19 +1,7 @@
 #include "config.h"
-
 #include "git2/config.h"
-#include "git2/sys/config.h"
-
-#include "buf_text.h"
-#include "config_backend.h"
-#include "regexp.h"
-#include "sysdir.h"
-#include "transaction.h"
+#include "git2/gitup_config.h"
 #include "vector.h"
-#if GIT_WIN32
-# include <windows.h>
-#endif
-
-#include <ctype.h>
 
 int gitup_config_find_local(git_repository *repo, git_buf *path)
 {

--- a/src/gitup_config.c
+++ b/src/gitup_config.c
@@ -1,0 +1,32 @@
+#include "config.h"
+
+#include "git2/config.h"
+#include "git2/sys/config.h"
+
+#include "buf_text.h"
+#include "config_backend.h"
+#include "regexp.h"
+#include "sysdir.h"
+#include "transaction.h"
+#include "vector.h"
+#if GIT_WIN32
+# include <windows.h>
+#endif
+
+#include <ctype.h>
+
+int git_config_find_local(git_repository *repo, git_buf *path)
+{
+	assert(repo);
+
+	git_buf_sanitize(path);
+	if (git_buf_joinpath(path, repo->gitdir, GIT_CONFIG_FILENAME_INREPO) < 0)
+    return -1;
+
+	if (!git_path_exists(path->ptr)) {
+		giterr_set(GITERR_OS, "The config file '%s' doesn't exist", path->ptr);
+		return GIT_ENOTFOUND;
+	}
+
+	return 0;
+}

--- a/src/gitup_refs.c
+++ b/src/gitup_refs.c
@@ -75,5 +75,5 @@ int gitup_reference_symbolic_create_virtual(
 {
 	int force = false;
 	const char *log_message = "";
-	return git_reference_symbolic_create(ref_out, repo, name, target, int force, log_message);
+	return git_reference_symbolic_create(ref_out, repo, name, target, force, log_message);
 }

--- a/src/gitup_refs.c
+++ b/src/gitup_refs.c
@@ -1,22 +1,14 @@
 #include "refs.h"
-
-#include "hash.h"
+#include "git2/refs.h"
+#include "git2/gitup_refs.h"
 #include "repository.h"
-#include "futils.h"
 #include "filebuf.h"
 #include "pack.h"
 #include "reflog.h"
 #include "refdb.h"
 
-#include <git2/tag.h>
-#include <git2/object.h>
 #include <git2/oid.h>
-#include <git2/branch.h>
-#include <git2/refs.h>
-#include <git2/refdb.h>
 #include <git2/sys/refs.h>
-#include <git2/signature.h>
-#include <git2/commit.h>
 
 int gitup_reference_create_virtual(
 	git_reference **ref_out,

--- a/src/gitup_refs.c
+++ b/src/gitup_refs.c
@@ -10,7 +10,7 @@
 #include <git2/oid.h>
 #include <git2/sys/refs.h>
 
-int gitup_reference_create_virtual(
+static int gitup_reference_create_virtual_old(
 	git_reference **ref_out,
 	git_repository *repo,
 	const char *name,
@@ -33,7 +33,18 @@ int gitup_reference_create_virtual(
 	return 0;
 }
 
-int gitup_reference_symbolic_create_virtual(
+int gitup_reference_create_virtual(
+	git_reference **ref_out,
+	git_repository *repo,
+	const char *name,
+	const git_oid *id)
+{
+	int force = false;
+	const char *log_message = "";
+	return git_reference_create(ref_out, repo, name, id, force, log_message);
+}
+
+static int gitup_reference_symbolic_create_virtual_old(
 	git_reference **ref_out,
 	git_repository *repo,
 	const char *name,
@@ -54,4 +65,15 @@ int gitup_reference_symbolic_create_virtual(
 
 	*ref_out = ref;
 	return 0;
+}
+
+int gitup_reference_symbolic_create_virtual(
+	git_reference **ref_out,
+	git_repository *repo,
+	const char *name,
+	const char *target)
+{
+	int force = false;
+	const char *log_message = "";
+	return git_reference_symbolic_create(ref_out, repo, name, target, int force, log_message);
 }

--- a/src/gitup_refs.c
+++ b/src/gitup_refs.c
@@ -1,0 +1,65 @@
+#include "refs.h"
+
+#include "hash.h"
+#include "repository.h"
+#include "futils.h"
+#include "filebuf.h"
+#include "pack.h"
+#include "reflog.h"
+#include "refdb.h"
+
+#include <git2/tag.h>
+#include <git2/object.h>
+#include <git2/oid.h>
+#include <git2/branch.h>
+#include <git2/refs.h>
+#include <git2/refdb.h>
+#include <git2/sys/refs.h>
+#include <git2/signature.h>
+#include <git2/commit.h>
+
+int gitup_reference_create_virtual(
+	git_reference **ref_out,
+	git_repository *repo,
+	const char *name,
+	const git_oid *id)
+{
+	int error;
+	git_refdb *refdb;
+	git_reference *ref;
+
+	assert(ref_out && repo && name && id);
+
+	if ((error = git_repository_refdb__weakptr(&refdb, repo)) < 0)
+		return error;
+
+	ref = git_reference__alloc(name, id, NULL);
+	GIT_REFCOUNT_INC(refdb);
+	ref->db = refdb;
+
+	*ref_out = ref;
+	return 0;
+}
+
+int gitup_reference_symbolic_create_virtual(
+	git_reference **ref_out,
+	git_repository *repo,
+	const char *name,
+	const char *target)
+{
+	int error;
+	git_refdb *refdb;
+	git_reference *ref;
+
+	assert(ref_out && repo && name && target);
+
+	if ((error = git_repository_refdb__weakptr(&refdb, repo)) < 0)
+		return error;
+
+	ref = git_reference__alloc_symbolic(name, target);
+	GIT_REFCOUNT_INC(refdb);
+	ref->db = refdb;
+
+	*ref_out = ref;
+	return 0;
+}

--- a/src/gitup_repository.c
+++ b/src/gitup_repository.c
@@ -5,40 +5,16 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "git2/gitup_repository.h"
-#include "git2/repository.h"
 #include "repository.h"
+#include "git2/repository.h"
+#include "git2/gitup_repository.h"
 
-#include <ctype.h>
-
-#include "git2/object.h"
-#include "git2/sys/repository.h"
-
-#include "common.h"
-#include "commit.h"
-#include "tag.h"
-#include "blob.h"
 #include "futils.h"
-#include "sysdir.h"
-#include "filebuf.h"
 #include "index.h"
 #include "config.h"
-#include "refs.h"
-#include "filter.h"
 #include "odb.h"
 #include "refdb.h"
-#include "remote.h"
-#include "merge.h"
 #include "diff_driver.h"
-#include "annotated_commit.h"
-#include "submodule.h"
-#include "worktree.h"
-
-#include "strmap.h"
-
-#ifdef GIT_WIN32
-# include "win32/w32_util.h"
-#endif
 
 int gitup_repository_update_gitlink(
 	git_repository *repo,

--- a/src/gitup_repository.c
+++ b/src/gitup_repository.c
@@ -40,7 +40,7 @@
 # include "win32/w32_util.h"
 #endif
 
-int git_repository_update_gitlink(
+int gitup_repository_update_gitlink(
 	git_repository *repo,
 	int use_relative_path)
 {

--- a/src/gitup_repository.c
+++ b/src/gitup_repository.c
@@ -32,3 +32,8 @@ int gitup_repository_update_gitlink(
 
 	return 0;
 }
+
+GIT_EXTERN(int) gitup_repository_local_config_path(git_buf *out, git_repository *repo)
+{
+    return git_repository_item_path(out, repo, GIT_REPOSITORY_ITEM_CONFIG);
+}

--- a/src/gitup_repository.c
+++ b/src/gitup_repository.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "git2/gitup_repository.h"
+#include "git2/repository.h"
+#include "repository.h"
+
+#include <ctype.h>
+
+#include "git2/object.h"
+#include "git2/sys/repository.h"
+
+#include "common.h"
+#include "commit.h"
+#include "tag.h"
+#include "blob.h"
+#include "futils.h"
+#include "sysdir.h"
+#include "filebuf.h"
+#include "index.h"
+#include "config.h"
+#include "refs.h"
+#include "filter.h"
+#include "odb.h"
+#include "refdb.h"
+#include "remote.h"
+#include "merge.h"
+#include "diff_driver.h"
+#include "annotated_commit.h"
+#include "submodule.h"
+#include "worktree.h"
+
+#include "strmap.h"
+
+#ifdef GIT_WIN32
+# include "win32/w32_util.h"
+#endif
+
+int git_repository_update_gitlink(
+	git_repository *repo,
+	int use_relative_path)
+{
+	int error;
+	const char *workdir = git_repository_workdir(repo);
+	int update_gitlink = 1;
+
+	if ((error = git_futils_mkdir(workdir, 0777, GIT_MKDIR_PATH | GIT_MKDIR_VERIFY_DIR)) < 0)
+		return error;
+
+	if ((error = git_repository_set_workdir(repo, workdir, update_gitlink)) < 0 )
+		return error;
+
+	return 0;
+}

--- a/src/gitup_submodule.c
+++ b/src/gitup_submodule.c
@@ -1,22 +1,13 @@
 #include "submodule.h"
+#include "git2/gitup_submodule.h"
 
-#include "git2/config.h"
-#include "git2/sys/config.h"
 #include "git2/types.h"
-#include "git2/index.h"
-#include "buffer.h"
-#include "buf_text.h"
 #include "vector.h"
 #include "posix.h"
-#include "config_backend.h"
 #include "config.h"
 #include "repository.h"
 #include "tree.h"
-#include "iterator.h"
-#include "path.h"
 #include "index.h"
-#include "worktree.h"
-#include "clone.h"
 
 /**
  * Retains a submodule

--- a/src/gitup_submodule.c
+++ b/src/gitup_submodule.c
@@ -1,0 +1,32 @@
+#include "submodule.h"
+
+#include "git2/config.h"
+#include "git2/sys/config.h"
+#include "git2/types.h"
+#include "git2/index.h"
+#include "buffer.h"
+#include "buf_text.h"
+#include "vector.h"
+#include "posix.h"
+#include "config_backend.h"
+#include "config.h"
+#include "repository.h"
+#include "tree.h"
+#include "iterator.h"
+#include "path.h"
+#include "index.h"
+#include "worktree.h"
+#include "clone.h"
+
+/**
+ * Retains a submodule
+ *
+ * @param submodule Submodule object
+ */
+// GIT_EXTERN(void) git_submodule_retain(git_submodule *submodule);
+void gitup_submodule_retain(git_submodule *sm)
+{
+	assert(sm);
+	GIT_REFCOUNT_INC(sm);
+}
+

--- a/src/push.c
+++ b/src/push.c
@@ -440,8 +440,9 @@ static int do_push(git_push *push, const git_remote_callbacks *callbacks)
 	if ((error = calculate_work(push)) < 0)
 		goto on_error;
 
+	/// PATCH
 	if (callbacks && callbacks->push_negotiation &&
-	    (error = callbacks->push_negotiation((const git_push_update **) push->updates.contents,
+	    (error = callbacks->push_negotiation(push->remote, (const git_push_update **) push->updates.contents,
 					  push->updates.length, callbacks->payload)) < 0)
 	    goto on_error;
 

--- a/src/streams/socket.c
+++ b/src/streams/socket.c
@@ -125,6 +125,18 @@ static int socket_connect(git_stream *stream)
 		return -1;
 	}
 
+	/// PATCH
+	/* Configure a 30 seconds timeout for recv() and send() on the socket */
+	struct timeval tv;
+	tv.tv_sec = 30;
+	tv.tv_usec = 0;
+	if (setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+		net_set_error("error setting socket receive timeout");
+	}
+	if (setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+		net_set_error("error setting socket send timeout");
+	}
+
 	st->s = s;
 	p_freeaddrinfo(info);
 	return 0;

--- a/src/streams/socket.c
+++ b/src/streams/socket.c
@@ -74,6 +74,7 @@ static int socket_connect(git_stream *stream)
 	struct addrinfo *info = NULL, *p;
 	struct addrinfo hints;
 	git_socket_stream *st = (git_socket_stream *) stream;
+    struct timeval tv; /// PATCH
 	GIT_SOCKET s = INVALID_SOCKET;
 	int ret;
 
@@ -127,7 +128,6 @@ static int socket_connect(git_stream *stream)
 
 	/// PATCH
 	/* Configure a 30 seconds timeout for recv() and send() on the socket */
-	struct timeval tv;
 	tv.tv_sec = 30;
 	tv.tv_usec = 0;
 	if (setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -362,10 +362,14 @@ static int _git_ssh_authenticate_session(
 		case GIT_CREDENTIAL_SSH_KEY: {
 			git_credential_ssh_key *c = (git_credential_ssh_key *)cred;
 
-			if (c->privatekey)
+			if (c->privatekey) {
 				rc = libssh2_userauth_publickey_fromfile(
 					session, c->username, c->publickey,
 					c->privatekey, c->passphrase);
+				/// PATCH: Invalid key file
+				if (rc == LIBSSH2_ERROR_FILE || rc == LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED)
+					rc = LIBSSH2_ERROR_AUTHENTICATION_FAILED;
+			} 
 			else
 				rc = ssh_agent_auth(session, c);
 

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -362,14 +362,10 @@ static int _git_ssh_authenticate_session(
 		case GIT_CREDENTIAL_SSH_KEY: {
 			git_credential_ssh_key *c = (git_credential_ssh_key *)cred;
 
-			if (c->privatekey) {
+			if (c->privatekey)
 				rc = libssh2_userauth_publickey_fromfile(
 					session, c->username, c->publickey,
 					c->privatekey, c->passphrase);
-				/// PATCH: Invalid key file
-				if (rc == LIBSSH2_ERROR_FILE || rc == LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED)
-					rc = LIBSSH2_ERROR_AUTHENTICATION_FAILED;
-			} 
 			else
 				rc = ssh_agent_auth(session, c);
 
@@ -430,6 +426,7 @@ static int _git_ssh_authenticate_session(
 
 	if (rc == LIBSSH2_ERROR_PASSWORD_EXPIRED ||
 		rc == LIBSSH2_ERROR_AUTHENTICATION_FAILED ||
+		rc == LIBSSH2_ERROR_FILE || /// PATCH: Invalid key file
 		rc == LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED)
 			return GIT_EAUTH;
 

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -452,6 +452,7 @@ static int request_creds(git_credential **out, ssh_subtransport *t, const char *
 		if (error == GIT_PASSTHROUGH) {
 			no_callback = 1;
 		} else if (error < 0) {
+			git_error_set(GIT_ERROR_SSH, "credentials callback returned an error");
 			return error;
 		} else if (!cred) {
 			git_error_set(GIT_ERROR_SSH, "callback failed to initialize SSH credentials");

--- a/tests/network/remote/push.c
+++ b/tests/network/remote/push.c
@@ -29,9 +29,12 @@ void test_network_remote_push__cleanup(void)
 	cl_fixture_cleanup("dummy.git");
 }
 
-int negotiation_cb(const git_push_update **updates, size_t len, void *payload)
+int negotiation_cb(git_remote *remote, const git_push_update **updates, size_t len, void *payload)
 {
 	const git_push_update *expected = payload;
+
+	/// PATCH
+	GIT_UNUSED(remote);
 
 	cl_assert_equal_i(1, len);
 	cl_assert_equal_s(expected->src_refname, updates[0]->src_refname);

--- a/update-xcode.sh
+++ b/update-xcode.sh
@@ -1,9 +1,25 @@
 #!/bin/sh
 
+SHOULD_OPEN_XCODE=$1
+
 export MACOSX_DEPLOYMENT_TARGET=10.10  # Must match GitUp
 
 rm -rf "xcode"
 mkdir "xcode"
 cd "xcode"
 cmake -G "Xcode" ..
-open "libgit2.xcodeproj"
+
+# We should copy a features.h file 
+# from ./xcode/src/git2/sys/features.h
+# to ./git2/sys/features.h
+
+cd ../
+mv "./xcode/src/git2/sys/features.h" "./include/git2/sys/features.h"
+
+# And open Xcode if needed.
+if [ "$SHOULD_OPEN_XCODE" = "" ]
+then
+	echo "Run Xcode if you need 'xed ./xcode/libgit2.xcodeproj'"
+else
+	open "./xcode/libgit2.xcodeproj"
+fi

--- a/update-xcode.sh
+++ b/update-xcode.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export MACOSX_DEPLOYMENT_TARGET=10.10  # Must match GitUp
+
+rm -rf "xcode"
+mkdir "xcode"
+cd "xcode"
+cmake -G "Xcode" ..
+open "libgit2.xcodeproj"


### PR DESCRIPTION
# NB: WIP

# Overview

If you check commits in branch `gitup`, you may notice, that some of them are merged into current libgit main branch. However, these commits have different commits hashes, so, it is easy to search via commit message.

Everything is merged prior to 694eff30a0 Added Xcode script.

These custom commits could be divided into three groups.
1. Already merged into libgit2 master.
2. Patch
3. Already merged into libgit2 but methods signatures are slightly different and patch still required with invocation of original method from libgit2 inside.

These custom commits could be divided by functionality.

1. libssh2 fixes.
2. libgit2 enhancements.

## Suggestion
I suggest to extract these methods into gitup extensions files. They have a prefix `gitup_`.
For `submodule.{h,c}` these files will be `gitup_submodule.{h,c}`.

Also these extensions will be imported by `gitup_extensions.h` header.

## Commits and groups

Done | Required | Group | Commit
------| ---- | ------ | -------
[/] | Unknown | libssh2 | f29d369a6 Allow passing invalid SSH key files
[/] | Required | libssh2 | 6f7b5f453 Configure a 30 seconds timeout for recv() and send() on new sockets
[/] | Required | libssh2 | 160885ff2 Fixed initialization of libssh2 sessions and set a default 30s timeout
[/] | Unknown | libssh2 | f826478dd Ensure errors returned by SSH and HTTP authentication callbacks are preserved
[x] | Unknown | libssh2 | 6722c185c Revert "Find libssh2 via pkg-config"
[ ] | Unknown | macOS missing API | 28c24ce63 Revert "p_futimes: support using futimens when available"
[/] | Required | Patch (Possible in main) | fc0392bbc Pass current remote to git_push_negotiation callback
[/] | Unknown | Patch (Possible in main) | 345fcee9e Added git_repository_update_gitlink() API
[/] | Unknown | Patch (Possible in main) | 4d4d2ead5 Added git_clone_into() API
[/] | Upstream PR | Patch (Possible for PR) | 9c912cfd7 Added git_branch_upstream_merge()
[x] | Upstream PR | Patch (Hard) | Exposed new SPI git_branch_upstream_name_from_merge_remote_names()
[/] | Unknown | Patch (Unknown) | 487c1a689 Added git_config_find_local()
[x] | Unknown | Patch (Unknown) | a83a27492 Add time metadata to git_diff_file
[/] | Upstream PR | Patch (Possible in main) | 8b6f0abe1 Added virtual references API
[x] | Upstream PR | Patch (Simple) | 57d4e3052 Added git_submodule_retain()
[x] | Required | Xcode | 694eff30a Added Xcode script
