### PR TITLE
Add git_index_forget_file

### DIFF
--- a/include/git2/gitup_index.h
+++ b/include/git2/gitup_index.h
@@ -1,0 +1,29 @@
+#include "common.h"
+#include "indexer.h"
+#include "types.h"
+#include "oid.h"
+#include "strarray.h"
+
+/**
+ * @file git2/index.h
+ * @brief Index (aka "cache" aka "staging area")
+ * @defgroup git_index Git index parsing and manipulation routines
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Forget the file associated with this index.
+ *
+ * This will prevent using operations that read
+ * or write to the index's on-disk file.
+ * This (probably) effectively makes this index
+ * indistinguishable from an in-memory index.
+ *
+ * @param index An index object
+ */
+GIT_EXTERN(void) git_index_forget_file(git_index *index);
+
+/** @} */
+GIT_END_DECL

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -3938,6 +3938,12 @@ void git_indexwriter_cleanup(git_indexwriter *writer)
 	writer->index = NULL;
 }
 
+void git_index_forget_file(git_index *index)
+{
+	index->index_file_path = NULL;
+	index->on_disk = 0;
+}
+
 /* Deprecated functions */
 
 #ifndef GIT_DEPRECATE_HARD


### PR DESCRIPTION
This adds git_index_forget_file:

> Forget the file associated with this index.
> 
> This will prevent using operations that read or write to the index's on-disk file. This (probably) effectively makes this index indistinguishable from an in-memory index.

This is useful when manipulating index structs, and needing to sever an on-disk index’s link to its associated file. [Retcon uses this](https://github.com/Cykelero/GitUp/blob/c88d71814c9cb62438b417b09eeefd7c93e8e885/GitUpKit/Core/GCLiveRepository.m#L805) in its caching architecture.